### PR TITLE
Fixes old call to sort() method

### DIFF
--- a/spr/__init__.py
+++ b/spr/__init__.py
@@ -3,6 +3,7 @@
 import re
 import copy
 import numpy as np
+from functools import cmp_to_key
 
 
 def load_raw(filename):
@@ -62,7 +63,7 @@ def load_raw(filename):
     ret["vars"] = []
     for i in m_vars:
         ret["vars"].append(i.groupdict())
-    ret["vars"].sort(cmp=lambda x, y: int(x["idx"])-int(y["idx"]))
+    ret["vars"].sort(key=cmp_to_key(lambda x, y: int(x["idx"])-int(y["idx"])))
 
     # values
     values = m.groupdict()["values"]


### PR DESCRIPTION
SPR 'master' fails to load raw ngspice data on python 3.6
```
>>> from spr import load_raw
>>> data=load_raw('SR-UWB.dat')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/....(entire path isn't relevant).../site-packages/spr/__init__.py", line 65, in load_raw
    ret["vars"].sort(cmp=lambda x, y: int(x["idx"])-int(y["idx"]))
TypeError: 'cmp' is an invalid keyword argument for this function
```

As stated somewhere on internet:

> Technical Detail: If you’re transitioning from Python 2 and are familiar with its function of the same name, you should be aware of a >couple important changes in Python 3:
> 
>    Python 3’s sorted() does not have a cmp parameter. Instead, only key is used to introduce custom sorting logic.
>    key and reverse must be passed as keyword arguments, unlike in Python 2, where they could be passed as positional arguments.
> 
> If you need to convert a Python 2 cmp function to a key function, then check out functools.cmp_to_key(). This tutorial will not cover any examples using Python 2.
> 

