### PR TITLE
Updated .sort() for Python 3

### DIFF
--- a/spr/__init__.py
+++ b/spr/__init__.py
@@ -3,6 +3,7 @@
 import re
 import copy
 import numpy as np
+from sys import version_info
 
 
 def load_raw(filename):
@@ -62,7 +63,10 @@ def load_raw(filename):
     ret["vars"] = []
     for i in m_vars:
         ret["vars"].append(i.groupdict())
-    ret["vars"].sort(cmp=lambda x, y: int(x["idx"])-int(y["idx"]))
+    if (version_info > (3,0)):
+        ret["vars"].sort(key=lambda x: int(x["idx"]) )
+    else:
+        ret["vars"].sort(cmp=lambda x, y: int(x["idx"])-int(y["idx"]))
 
     # values
     values = m.groupdict()["values"]


### PR DESCRIPTION
Added a check for Python version, using a new sort with the key parameter for v > 3.0 and the old sort (with cmp) otherwise.